### PR TITLE
Fixes cURL issue and makes wget act identically. #2098

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,7 +107,7 @@ class composer(
       $method_package = $curl_package
     }
     'wget': {
-      $download_command = 'wget https://getcomposer.org/composer.phar -O composer.phar'
+      $download_command = "wget -qO- https://getcomposer.org/installer | ${composer::php_bin}"
       $download_require = $suhosin_enabled ? {
         false   => [ Package['wget', $php_package] ],
         default => [
@@ -143,6 +143,7 @@ class composer(
       require   => $download_require,
       creates   => "${tmp_path}/composer.phar",
       logoutput => $logoutput,
+      environment => "COMPOSER_HOME={$composer_home}",
     }
     # move file to target_dir
     file { "${target_dir}/${composer_file}":


### PR DESCRIPTION
This fixes the cURL issue outlined in issue puphpet/puphpet#2098.

The composer installer expects an environment variable "COMPOSER_HOME", which does not exist upon running the composer installer.

There are also two different installation methods, namely curl and wget, which previously operated two very seperate ways. One downloading composer and the other downloading the composer installer, hence the previous remedy for fixing curl was to switch to wget. This has been changed so both wget and curl download the installer, and run as expected.
